### PR TITLE
Add dockerfile and vscode container env file

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:bookworm-slim
+
+# Install system deps
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates build-essential pkg-config libssl-dev git sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install rustup + Rust system-wide
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --no-modify-path \
+    && chmod -R a+w /root/.cargo /root/.rustup
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Create non-root user "vscode" with sudo rights
+RUN useradd -m vscode && echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+    && mkdir -p /home/vscode/.cargo /home/vscode/.rustup \
+    && cp -r /root/.cargo /home/vscode/ \
+    && cp -r /root/.rustup /home/vscode/ \
+    && chown -R vscode:vscode /home/vscode/.cargo /home/vscode/.rustup
+
+USER vscode
+WORKDIR /workspace
+
+# Make sure cargo & rustc are in PATH for vscode user
+ENV PATH="/home/vscode/.cargo/bin:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "Rust Dev",
+  "dockerFile": "Dockerfile",
+  "context": "..",
+  "remoteUser": "vscode",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "ms-vscode.cpptools",
+        "vadimcn.vscode-lldb"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Add Dockerfile and VS Code Dev Container Environment

## 📦 Summary
This PR introduces a **Docker-based development environment** along with a **VS Code devcontainer configuration**.  
The goal is to provide a reproducible, containerized setup so that contributors can quickly start developing without manually installing dependencies.

## 🔧 Changes
- Added a `Dockerfile` that installs Rust, Cargo, and necessary system dependencies.
- Added `.devcontainer/devcontainer.json` to enable VS Code Remote - Containers support.
- Configured the container to use a non-root `vscode` user with sudo privileges.
- Installed useful VS Code extensions:
  - `rust-lang.rust-analyzer` for Rust language support.
  - `vadimcn.vscode-lldb` for debugging.
  - `ms-vscode.cpptools` for C/C++ integration (useful for crates with native deps).

## ✅ Benefits
- Consistent environment for all developers.
- No need to install Rust toolchain locally.
- Easy onboarding: contributors just need Docker + VS Code with *Dev Containers* extension.
- Reproducible builds and dependency management.

## 🔍 How to Test
1. Install [Docker](https://docs.docker.com/get-docker/) and [VS Code Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
2. Open the repository in VS Code.
3. Run **“Reopen in Container”**.
4. Verify that:
   - Rust toolchain is available: `cargo --version`.
   - You can build the project: `cargo build`.
   - Extensions are working inside the container.

## 📌 Notes
- The container setup can be extended in the future to include additional tools like `clippy`, `rustfmt`, or testing dependencies.
- For now, the focus is on providing a minimal but functional Rust environment.

---
